### PR TITLE
Updated connection logic for Mongoose >= 4.11.0

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -21,7 +21,7 @@ app.use(function(req, res, next) {
 });
 
 // Connect to MongoDB
-mongoose.connect('mongodb://localhost/meanapp');
+mongoose.connect('mongodb://localhost/meanapp', { useMongoClient: true });
 mongoose.connection.once('open', function() {
 
   // Load the models.


### PR DESCRIPTION
Mongoose's default connection logic is deprecated as of 4.11.0. The `useMongoClient` option must be set if using `connect()`. See http://mongoosejs.com/docs/connections.html#use-mongo-client.